### PR TITLE
Revert favourite 1 back to CMD_FAV

### DIFF
--- a/neo_smart_blind.py
+++ b/neo_smart_blind.py
@@ -10,6 +10,7 @@ from .const import (
     CMD_DOWN,
     CMD_DOWN2,
     CMD_STOP,
+    CMD_FAV,
     CMD_FAV_1,
     CMD_FAV_2,
 )
@@ -31,7 +32,7 @@ class NeoSmartBlind:
     def adjust_blind(self, pos):
         """Adjust the blind based on the pos value send"""
         if pos == 50:
-            self.send_command(CMD_FAV_1)
+            self.send_command(CMD_FAV)
             return
         if pos == 51:
             self.send_command(CMD_FAV_2)


### PR DESCRIPTION
In the case that there are controllers that don't support the i1/i2 commands and require gp for favourite 1, I have made it use that value for favourite 1.

From the tech support at neoblinds gp and i1 are equivalent.  i2 will only be used for favourite 2.