### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/neosmartblinds/manifest.json
+++ b/custom_components/neosmartblinds/manifest.json
@@ -5,5 +5,5 @@
   "codeowners": ["4n0nD3v3l0p3r","mtgeekman","clara-j","gee-jay-bee"],
   "name": "NeoSmartBlinds",
   "version": "2.2",
-  "requirements": ["requests==2.28.1"]
+  "requirements": ["requests==2.28.2"]
 }


### PR DESCRIPTION
Homeassistant 2023.3.1 bumped requests to 2.28.2 - https://github.com/home-assistant/core/pull/88956 

After applying 2023.3.1 the component will fail to load due to a missing dependency, bumping the requirment to 2.28.2 resolves the issue